### PR TITLE
Fix exec file in current path or given absolute path

### DIFF
--- a/with
+++ b/with
@@ -171,8 +171,8 @@ print_prompt() {
 
     "${SED_COMMAND_LINE[@]}" -e "s/%nc%/$__nc/g"
   }
-
-  echo -n "$*" | colorise_prompt | sed -E -e "s/%prefix%/$__prefix/g" \
+  local __escaped_prefix=$(echo -n "$__prefix" | sed -e 's/\./\\./g' -e 's/\//\\\//g')
+  echo -n "$*" | colorise_prompt | sed -E -e "s/%prefix%/$__escaped_prefix/g" \
                                           -e "s/\\$/$(hashdollar)/g"
 }
 


### PR DESCRIPTION
Minor fix.

Escaped prefix(only . and \ are escaped) before passing to sed. 

``` scala
trevor@base2theory:~/workspace/git/mchav/with$ ./with ./with
sed: couldn't open file ith/g: No such file or directory
^C
```

Now 

``` scala
trevor@base2theory:~/workspace/git/trevorsibanda/with$ ./with ./with
$ ./with > +./with
$ ./with ./with > git
$ ./with git > 
```
