### PR TITLE
Do not source /* if BASH_COMPLETION_COMPAT_DIR is unset

### DIFF
--- a/with
+++ b/with
@@ -59,7 +59,10 @@ setup()
   [ -f /etc/bash_completion ] && source /etc/bash_completion
 
   BASH_COMPLETION_DEFAULT_DIR=/usr/share/bash-completion/completions
-  for completion_file in $BASH_COMPLETION_DEFAULT_DIR/* $BASH_COMPLETION_COMPAT_DIR/*
+  BASH_COMPLETION_COMPAT_DIR_GLOB=
+  [ -n "$BASH_COMPLETION_COMPAT_DIR" ] \
+    && BASH_COMPLETION_COMPAT_DIR_GLOB=$BASH_COMPLETION_COMPAT_DIR/*
+  for completion_file in $BASH_COMPLETION_DEFAULT_DIR/* $BASH_COMPLETION_COMPAT_DIR_GLOB
   do
     . "$completion_file" &> /dev/null
   done


### PR DESCRIPTION
If BASH_COMPLETION_COMPAT_DIR was unset it tried to source /*
wich lead to repl not showing up if there were files in / that
lead no termination of sourcing. This could potentially do harm
if there is a harmful script in /.

$BASH_COMPLETION_DEFAULT_DIR/* will now only be sourced if
BASH_COMPLETION_DEFAULT_DIR is set and is not empty.