### PR TITLE
fix: make installer fail fast

### DIFF
--- a/install
+++ b/install
@@ -16,7 +16,9 @@ else
   BASH_COMPLETION_D=/etc/bash_completion.d
 fi
 
+CURL=(curl -fsSL)
+
 echo "Installing with"
-curl -fsSL https://raw.githubusercontent.com/mchav/with/master/with -o "$BIN/with" && chmod +x "$BIN/with"
-curl -fsSL https://raw.githubusercontent.com/mchav/with/master/with.bash-completion -o "$BASH_COMPLETION_D/with.bash-completion"
+"${CURL[@]}"  https://raw.githubusercontent.com/mchav/with/master/with -o "$BIN/with" && chmod +x "$BIN/with"
+"${CURL[@]}"  https://raw.githubusercontent.com/mchav/with/master/with.bash-completion -o "$BASH_COMPLETION_D/with.bash-completion"
 echo "with successfully installed!"

--- a/install
+++ b/install
@@ -1,23 +1,22 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-if (( `uname` == "Darwin" )); then
+if [[ "$(uname)" == "Darwin" ]]; then
   BIN=/usr/local/bin
   BASH_COMPLETION_D=/usr/local/etc/bash_completion.d
-  CURL=curl
 else
-  # check if user is root 
+  # check if user is root
   # and re-exec the script with sudo if not
   #
   # equivalent to: [ "$(whoami)" != "root" ] && exec sudo -- "$0" "$@"
   # bash only, but without external call to whoami
-  # 
+  #
   (( EUID != 0 )) && exec sudo -- "$0" "$@"
   BIN=/usr/bin
   BASH_COMPLETION_D=/etc/bash_completion.d
-  CURL="sudo curl"
 fi
 
 echo "Installing with"
-$CURL -s https://raw.githubusercontent.com/mchav/with/master/with -o $BIN/with && chmod +x $BIN/with
-$CURL -s https://raw.githubusercontent.com/mchav/with/master/with.bash-completion -o $BASH_COMPLETION_D/with.bash-completion
+curl -fsSL https://raw.githubusercontent.com/mchav/with/master/with -o "$BIN/with" && chmod +x "$BIN/with"
+curl -fsSL https://raw.githubusercontent.com/mchav/with/master/with.bash-completion -o "$BASH_COMPLETION_D/with.bash-completion"
 echo "with successfully installed!"


### PR DESCRIPTION
Hi @mchav 👋  
I’ve put together a small fix related to **Issue #50**.  
When you have a moment, I’d really appreciate it if you could take a look.

---

## Overview

This PR addresses a case where the installer script reports a successful
installation even though one or more commands have actually failed.

The intent of this change is straightforward:  
**installation errors should never be silently ignored.**

---

## What problem this PR addresses (Issue #50)

At the moment, the installer script can:

- Encounter an error during installation (e.g. download failure, permission issue)
- Still print `with successfully installed!`
- Exit with a success status despite the installation not completing correctly

As a result, users may believe the installation succeeded when it did not.

---

## What this PR does

This PR is intentionally scoped to **error handling only**.

Specifically, it:

- Enables fail-fast behavior using `set -euo pipefail`
- Uses `curl -f` so HTTP errors are treated as failures
- Ensures the success message is printed **only when all steps succeed**

With this change, any failure during installation will cause the script to
exit immediately instead of reporting success.

---

## Scope of this PR

To keep the change minimal and easy to review, this PR deliberately does **not**:

- Change installation paths
- Modify platform-specific behavior
- Create missing directories automatically
- Update README or other documentation

These topics can be addressed separately if needed.

---

## Why this change is useful

- Prevents false-positive “successful installation” messages
- Makes installation failures immediately visible
- Improves reliability without altering the existing install flow

---

### Follow-up (out of scope for this PR)

There may be opportunities to further improve the installer, such as revisiting
macOS-specific installation paths (e.g. bash vs zsh defaults or Homebrew-related
locations).  
However, I’d prefer to handle those in a separate follow-up PR to keep this one
focused.

Thanks for your time and for maintaining the project!